### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -311,7 +311,7 @@ jobs:
         shell: bash
 
       - name: Base Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: statping/statping
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -320,7 +320,7 @@ jobs:
           tags: "base"
 
       - name: Dev Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           VERSION: ${{ env.VERSION }}
           ARCH: amd64

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -413,7 +413,7 @@ jobs:
         shell: bash
 
       - name: Base Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: statping/statping
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -422,7 +422,7 @@ jobs:
           tags: "base"
 
       - name: Latest/Version Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           VERSION: ${{ env.VERSION }}
           ARCH: amd64


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore